### PR TITLE
[hooks] Allow changing cursor path dynamically

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -228,7 +228,7 @@ const List = function(props) {
   // Using a function so that your cursors' path can use the component's props etc.
   const {colors} = useBranch({
     colors: [props.alternative ? 'alternativeColors' : 'colors']
-  });
+  }, [props.alternative]);
 
   function renderItem(color) {
     return <li key={color}>{color}</li>;
@@ -239,6 +239,8 @@ const List = function(props) {
 
 export default List;
 ```
+
+Note that you need to pass an array of dependencies as a second argument. If dependencies are not specified, the path will not be re-computed.
 
 ### Clever vs. dumb components
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -41,7 +41,7 @@ export function useRoot(tree) {
   return state;
 }
 
-export function useBranch(cursors) {
+export function useBranch(cursors, deps) {
   if (!isPlainObject(cursors) && typeof cursors !== 'function')
     invalidMapping(name, cursors);
 
@@ -63,14 +63,19 @@ export function useBranch(cursors) {
     const mapping = typeof cursors === 'function' ? cursors(context) : cursors;
     const watcher = context.tree.watch(mapping);
 
-    watcher.on('update', () => {
+    const updateValue = () => {
       const obj = watcher.get();
       obj.dispatch = (fn, ...args) => fn(context.tree, ...args);
       setState(obj);
-    });
+    };
+
+    // cursors have changed - update value immediately
+    updateValue();
+
+    watcher.on('update', updateValue);
 
     return () => watcher.release();
-  }, [cursors]);
+  }, deps || []);
 
   return state;
 }

--- a/test/hook.jsx
+++ b/test/hook.jsx
@@ -154,7 +154,7 @@ describe('Hook', function() {
             name: ['name'],
             surname: props.path
           };
-        });
+        }, [props.path]);
         return (
           <span>
             Hello {data.name} {data.surname}


### PR DESCRIPTION
With the current implementation, when `cursors` changes, a new watcher
is created and we subscribe to "update" event. The issue is, if the
value under new path never changes, `useBranch` will always return the
value from the previous path.

In example below (from documentation), changing `alternative` prop
will not change `colors` after first render.

```js
import React, {Component} from 'react';
import {useBranch} from 'baobab-react/hooks';

const List = function(props) {
  // Using a function so that your cursors' path can use the component's props etc.
  const {colors} = useBranch({
    colors: [props.alternative ? 'alternativeColors' : 'colors']
  });

  function renderItem(color) {
    return <li key={color}>{color}</li>;
  }

  return <ul>{colors.map(renderItem)}</ul>;
}

export default List;
```

Fix this by re-fetching the current value in the `useEffect`.

Another issue is that with the current examples, `selectors` changes
on every render. Passing in an object or function inline will create a
new instance of object on every render, triggering watcher
re-creation.

With the fix above, that leads to an infinite loop:

- `useEffect` sets new value for `state`
- updating `state` triggers a render
- render creates a new `selectors` triggering `useEffect`

Fix this by adding a `deps` argument that should hold an array of
dependencies to trigger re-subscription. The default value is now an
empty array to break the infinite loop and be more
backward-compatible.

Another alternative is to use `useMemo` to memoize selectors in
examples, but that is overly-verbose and would require a lot of
migration effort for users.